### PR TITLE
Fix: Chinese encoding error on Safari

### DIFF
--- a/autoelective/captcha/__init__.py
+++ b/autoelective/captcha/__init__.py
@@ -3,5 +3,5 @@
 # filename: __init__.py
 # modified: 2019-09-08
 
-from .captcha import Captcha
+from .captcha_util import Captcha
 from .online import TTShituRecognizer

--- a/autoelective/captcha/online.py
+++ b/autoelective/captcha/online.py
@@ -5,7 +5,7 @@ import json
 import requests
 from PIL import Image
 
-from .captcha import Captcha
+from .captcha_util import Captcha
 from ..config import BaseConfig
 from .._internal import get_abs_path
 from ..exceptions import OperationFailedError, OperationTimeoutError, RecognizerError

--- a/autoelective/monitor.py
+++ b/autoelective/monitor.py
@@ -20,6 +20,7 @@ monitor = Flask(__name__, static_folder=None) # disable static rule
 
 monitor.config["JSON_AS_ASCII"] = False
 monitor.config["JSON_SORT_KEYS"] = False
+monitor.config['JSONIFY_MIMETYPE'] = "application/json;charset=utf-8"
 
 _werkzeug_internal._logger = cout  # custom _logger for werkzeug
 


### PR DESCRIPTION
1. 修复了 `monitor.py` 的 flask 服务器在 Safari 中文编码异常问题。
2. 修复了 .captcha 引用问题。